### PR TITLE
Add rtosc to build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -124,9 +124,9 @@ amsynth_SOURCES = \
 	src/main.h \
 	src/main.cpp
 
-amsynth_CPPFLAGS = $(AM_CPPFLAGS) @ALSA_CFLAGS@ @JACK_CFLAGS@ @LASH_CFLAGS@ @GTK_CFLAGS@
+amsynth_CPPFLAGS = $(AM_CPPFLAGS) @ALSA_CFLAGS@ @JACK_CFLAGS@ @LASH_CFLAGS@ @GTK_CFLAGS@ @rtosc_CFLAGS@
 
-amsynth_LDADD = @ALSA_LIBS@ @JACK_LIBS@ @LASH_LIBS@ @LIBS@
+amsynth_LDADD = @ALSA_LIBS@ @JACK_LIBS@ @LASH_LIBS@ @rtosc_LIBS@ @LIBS@
 
 if BUILD_GUI
 amsynth_SOURCES += $(libgui_sources) \

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,12 @@ AS_IF([test "x$with_lash" != "xno"], [
         AC_DEFINE([WITH_LASH],, [Use this optional package])
         with_lash="yes"], [with_lash="no"])])
 
+AC_ARG_WITH([rtosc], [AS_HELP_STRING([--with-rtosc], [build support for rtosc])])
+AS_IF([test "x$with_rtosc" != "xno"], [
+    PKG_CHECK_MODULES([rtosc], [librtosc], [
+        AC_DEFINE([WITH_RTOSC],, [Use this optional package])
+        with_rtosc="yes"], [with_rtosc="no"])])
+
 AC_ARG_WITH([dssi], [AS_HELP_STRING([--with-dssi], [build DSSI plugin])])
 AS_IF([test "x$with_dssi" != "xno"], [
     PKG_CHECK_MODULES([DSSI], [dssi], [

--- a/src/JackOutput.cpp
+++ b/src/JackOutput.cpp
@@ -99,7 +99,7 @@ JackOutput::init()
 	/* create midi input port(s) */
 	m_port = jack_port_register(client, "midi_in", JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0);
 	m_port_out = jack_port_register(client, "midi_out", JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0);
-#if ENABLE_OSC
+#ifdef WITH_RTOSC
 	// TODO switch to the new event API if available
 	// TODO add metadata to the port
 	osc_port = jack_port_register(client, "osc_in", JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0);
@@ -167,7 +167,7 @@ JackOutput::process (jack_nframes_t nframes, void *arg)
 			midi_events.push_back(amsynth_midi_event_make(midi_event));
 		}
 	}
-#if ENABLE_OSC
+#ifdef WITH_RTOSC
 	if (self->osc_port) {
 		void *port_buf = jack_port_get_buffer(self->osc_port, nframes);
 		const jack_nframes_t event_count = jack_midi_get_event_count(port_buf);

--- a/src/Synthesizer.cpp
+++ b/src/Synthesizer.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 #include <cstring>
 
-#if ENABLE_OSC
+#ifdef WITH_RTOSC
 #include <rtosc/rtosc.h>
 #include <rtosc/ports.h>
 #include <rtosc/port-sugar.h>
@@ -279,7 +279,7 @@ void Synthesizer::process(unsigned int nframes,
 		return;
 	}
 
-#if ENABLE_OSC
+#ifdef WITH_RTOSC
 	rtosc::RtData rtData = rtosc::RtData();
 	for (std::vector<amsynth_osc_event_t>::const_iterator event = osc_in.begin(); event != osc_in.end(); event++) {
 		ports.dispatch(event->buffer, rtData, true);


### PR DESCRIPTION
This adds `rtosc` to the build system.

Building fails because rtosc requires C++11 and this project is still on C++98.
There is a ticket that discusses upgrading to C++11 - https://github.com/amsynth/amsynth/issues/130 - but I wonder can we get anywhere with just rtosc's C layer?